### PR TITLE
[Issue 56]: Date rounding bug

### DIFF
--- a/frontend/src/utils/dateUtil.ts
+++ b/frontend/src/utils/dateUtil.ts
@@ -3,7 +3,12 @@ export function formatDate(dateStr: string | null) {
   if (dateStr === "" || dateStr === null) {
     return "";
   }
-  const date = new Date(dateStr);
+
+  const [year, month, day] = dateStr.split("-").map(Number);
+
+  // Create a new Date object using the local time
+  const date = new Date(year, month - 1, day);
+
   const options: Intl.DateTimeFormatOptions = {
     year: "numeric",
     month: "long",

--- a/frontend/tests/components/search/SearchResultsListItem.test.tsx
+++ b/frontend/tests/components/search/SearchResultsListItem.test.tsx
@@ -34,4 +34,34 @@ describe("SearchResultsListItem", () => {
     expect(screen.getByText("Test Opportunity")).toBeInTheDocument();
     expect(screen.getByText("OPP-12345")).toBeInTheDocument();
   });
+
+  getDateTestCases().forEach(({ api_date, ui_date }) => {
+    it(`renders formatted date ${ui_date} for API date ${api_date}`, () => {
+      const opportunityWithDate = {
+        ...mockOpportunity,
+        summary: {
+          ...mockOpportunity.summary,
+          post_date: api_date,
+        },
+      };
+
+      render(<SearchResultsListItem opportunity={opportunityWithDate} />);
+      expect(screen.getByText(ui_date)).toBeInTheDocument();
+    });
+  });
 });
+
+function getDateTestCases() {
+  return [
+    { api_date: "2024-05-01", ui_date: "May 1, 2024" },
+    { api_date: "2023-07-21", ui_date: "July 21, 2023" },
+    { api_date: "2022-11-30", ui_date: "November 30, 2022" },
+    { api_date: "2021-01-15", ui_date: "January 15, 2021" },
+    { api_date: "2020-06-17", ui_date: "June 17, 2020" },
+    { api_date: "2019-08-25", ui_date: "August 25, 2019" },
+    { api_date: "2018-12-05", ui_date: "December 5, 2018" },
+    { api_date: "2017-09-13", ui_date: "September 13, 2017" },
+    { api_date: "2016-04-07", ui_date: "April 7, 2016" },
+    { api_date: "2015-03-23", ui_date: "March 23, 2015" },
+  ];
+}


### PR DESCRIPTION
## Summary
Fixes #56 

### Time to review: 2 min

## Changes proposed
- Update the date creation to the parsed year/month/day so it creates the `Date` object using the local time - this may prevent any type of rounding
- Add some tests to ensure the right dates are showing up on search
