### PR TITLE
[Issue #58] Locally, preserve the auth token in the OpenAPI across refreshes

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -5,6 +5,8 @@
 ENVIRONMENT=local
 PORT=8080
 
+PERSIST_AUTHORIZATION_OPENAPI=TRUE
+
 # Python path needs to be specified
 # for pytest to find the implementation code
 PYTHONPATH=/api/

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -16,6 +16,7 @@ from src.api.opportunities_v0_1 import opportunity_blueprint as opportunities_v0
 from src.api.opportunities_v1 import opportunity_blueprint as opportunities_v1_blueprint
 from src.api.response import restructure_error_response
 from src.api.schemas import response_schema
+from src.app_config import AppConfig
 from src.auth.api_key_auth import get_app_security_scheme
 from src.data_migration.data_migration_blueprint import data_migration_blueprint
 from src.search.backend.load_search_data_blueprint import load_search_data_blueprint
@@ -61,6 +62,8 @@ def register_db_client(app: APIFlask) -> None:
 
 
 def configure_app(app: APIFlask) -> None:
+    app_config = AppConfig()
+
     # Modify the response schema to instead use the format of our ApiResponse class
     # which adds additional details to the object.
     # https://apiflask.com/schema/#base-response-schema-customization
@@ -70,6 +73,9 @@ def configure_app(app: APIFlask) -> None:
     app.config["SWAGGER_UI_CSS"] = "/static/swagger-ui.min.css"
     app.config["SWAGGER_UI_BUNDLE_JS"] = "/static/swagger-ui-bundle.js"
     app.config["SWAGGER_UI_STANDALONE_PRESET_JS"] = "/static/swagger-ui-standalone-preset.js"
+    app.config["SWAGGER_UI_CONFIG"] = {
+        "persistAuthorization": app_config.persist_authorization_openapi
+    }
     # Removing because the server dropdown has accessibility issues.
     app.config["SERVERS"] = "."
     app.config["DOCS_FAVICON"] = "https://simpler.grants.gov/img/favicon.ico"

--- a/api/src/app_config.py
+++ b/api/src/app_config.py
@@ -9,3 +9,7 @@ class AppConfig(PydanticBaseEnvConfig):
     # See https://flask.palletsprojects.com/en/2.2.x/api/#flask.Flask.run
     host: str = "127.0.0.1"
     port: int = 8080
+
+    # For the OpenAPI docs, set whether the auth tokens are stored
+    # across refreshes of the page. Currently we only set this to true locally
+    persist_authorization_openapi: bool = False


### PR DESCRIPTION
## Summary
Fixes #58

### Time to review: __3 mins__

## Changes proposed
Set the `persistAuthorization` OpenAPI config locally to True

## Context for reviewers
For local development, we frequently need to go to http://localhost:8080/docs - enter the auth token, and then repeat this process every time we reopen this page or refresh. Having to either copy paste or retype in the auth token is tedious. This flag makes it so it gets preserved in your browsers local storage.

We are only enabling this for the local endpoint at the moment as there are possibly security implications we would need to consider non-locally (eg. what if someone is using a public computer).


