### PR TITLE
[DO NOT MERGE - PROTOTYPE] [Issue #22] Prototype download endpoint

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -29,3 +29,5 @@ coverage.*
 
 #e2e
 /test-results/
+
+/volume

--- a/api/Makefile
+++ b/api/Makefile
@@ -129,6 +129,10 @@ start-db:
 ## Destroy current DB, setup new one
 db-recreate: clean-volumes init-db
 
+# TODO
+start-localstack:
+	docker-compose up --detach localstack
+
 #########################
 # DB Migrations
 #########################

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -47,6 +47,22 @@ services:
       - 'OPENSEARCH_HOSTS=["http://opensearch-node:9200"]'
       - DISABLE_SECURITY_DASHBOARDS_PLUGIN=true # disables security dashboards plugin in OpenSearch Dashboards
 
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
+    image: localstack/localstack
+    ports:
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+    environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      - DEBUG=${DEBUG:-0}
+      # To improve startup time, only add services we use
+      - SERVICES=s3
+      - EAGER_SERVICES_LOADING=1
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
   grants-api:
     build:
       context: .
@@ -64,6 +80,9 @@ services:
     depends_on:
       - grants-db
       - opensearch-node
+      - localstack
+
+
 
 volumes:
   grantsdbdata:

--- a/api/myfile.txt
+++ b/api/myfile.txt
@@ -1,0 +1,1 @@
+i am a file

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -34,55 +34,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/Healthcheck'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id001
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id002
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/Healthcheck'
           description: Successful response
         '503':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id001
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id002
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Service Unavailable
       tags:
       - Health
@@ -101,83 +59,21 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/OpportunityV0'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id003
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id004
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                type: array
+                items:
+                  $ref: '#/components/schemas/OpportunityV0'
           description: Successful response
         '422':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id003
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id004
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Validation error
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id003
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id004
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
       tags:
       - Opportunity v0
@@ -213,83 +109,21 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/OpportunityV1'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id005
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id006
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                type: array
+                items:
+                  $ref: '#/components/schemas/OpportunityV1'
           description: Successful response
         '422':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id005
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id006
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Validation error
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id005
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id006
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
       tags:
       - Opportunity v1
@@ -325,83 +159,21 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/OpportunityV01'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id007
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id008
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                type: array
+                items:
+                  $ref: '#/components/schemas/OpportunityV01'
           description: Successful response
         '422':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id007
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id008
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Validation error
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id007
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id008
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
       tags:
       - Opportunity v0.1
@@ -483,81 +255,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/OpportunityV0'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id009
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id010
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/OpportunityV0'
           description: Successful response
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id009
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id010
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
         '404':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id009
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id010
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Not found
       tags:
       - Opportunity v0
@@ -593,81 +303,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/OpportunityV1'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id011
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id012
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/OpportunityGetResponseV1'
           description: Successful response
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id011
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id012
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
         '404':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id011
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id012
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Not found
       tags:
       - Opportunity v1
@@ -703,81 +351,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/OpportunityV01'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: &id013
-                    - object
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: &id014
-                      - object
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/OpportunityV01'
           description: Successful response
         '401':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id013
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id014
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Authentication error
         '404':
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    description: The message to return
-                  data:
-                    $ref: '#/components/schemas/ErrorResponse'
-                  status_code:
-                    type: integer
-                    description: The HTTP status code
-                  pagination_info:
-                    description: The pagination information for paginated endpoints
-                    type: *id013
-                    allOf:
-                    - $ref: '#/components/schemas/PaginationInfo'
-                  warnings:
-                    type: array
-                    items:
-                      type: *id014
-                      allOf:
-                      - $ref: '#/components/schemas/ValidationIssue'
+                $ref: '#/components/schemas/ErrorResponse'
           description: Not found
       tags:
       - Opportunity v0.1
@@ -800,39 +386,42 @@ paths:
         '
       security:
       - ApiKeyAuth: []
+  /v1/opportunities/{opportunity_id}/attachment/{attachment_id}:
+    get:
+      parameters:
+      - in: path
+        name: opportunity_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: attachment_id
+        schema:
+          type: integer
+        required: true
+      responses:
+        '302':
+          content:
+            application/json:
+              schema: {}
+          description: Successful response
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+      tags:
+      - Opportunity v1
+      summary: Get Opportunity File
 openapi: 3.1.0
 components:
   schemas:
-    PaginationInfo:
+    Healthcheck:
       type: object
       properties:
-        page_offset:
-          type: integer
-          description: The page number that was fetched
-          example: 1
-        page_size:
-          type: integer
-          description: The size of the page fetched
-          example: 25
-        total_records:
-          type: integer
-          description: The total number of records fetchable
-          example: 42
-        total_pages:
-          type: integer
-          description: The total number of pages that can be fetched
-          example: 2
-        order_by:
+        message:
           type: string
-          description: The field that the records were sorted by
-          example: id
-        sort_direction:
-          description: The direction the records are sorted
-          enum:
-          - ascending
-          - descending
-          type:
-          - string
     ValidationIssue:
       type: object
       properties:
@@ -845,22 +434,9 @@ components:
         field:
           type: string
           description: The field that failed
-    Healthcheck:
-      type: object
-      properties:
-        message:
-          type: string
     ErrorResponse:
       type: object
       properties:
-        message:
-          type: string
-          description: The message to return
-        data:
-          description: The REST resource object
-        status_code:
-          type: integer
-          description: The HTTP status code
         errors:
           type: array
           items:
@@ -868,6 +444,10 @@ components:
             - object
             allOf:
             - $ref: '#/components/schemas/ValidationIssue'
+        status_code:
+          type: integer
+          description: The HTTP status code
+          example: 404
     OpportunitySorting:
       type: object
       properties:
@@ -1889,6 +1469,20 @@ components:
           type: string
           format: date-time
           readOnly: true
+    OpportunityGetResponseV1:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message to return
+        data:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/OpportunityV1'
+        status_code:
+          type: integer
+          description: The HTTP status code
   securitySchemes:
     ApiKeyAuth:
       type: apiKey

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -1,4 +1,5 @@
 from src.api.schemas.extension import Schema, fields, validators
+from src.api.schemas.response_schema import AbstractResponseSchema, AbstractPaginationResponseSchema
 from src.api.schemas.search_schema import StrSearchSchemaBuilder
 from src.constants.lookup_constants import (
     ApplicantType,
@@ -296,3 +297,15 @@ class OpportunitySearchRequestV1Schema(Schema):
         ),
         required=True,
     )
+
+class OutputFileSchema(Schema):
+
+    type = fields.String()
+    format = fields.String()
+
+
+class OpportunityGetResponseV1Schema(AbstractResponseSchema):
+    data = fields.Nested(OpportunityV1Schema())
+
+class OpportunityListResponseV1Schema(AbstractPaginationResponseSchema):
+    data = fields.Nested(OpportunityV1Schema(many=True))

--- a/api/src/api/response.py
+++ b/api/src/api/response.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 from typing import Any, Optional, Tuple
-
+import flask
 import apiflask
 
 from src.api.schemas.extension import MarshmallowErrorContainer
@@ -45,6 +45,12 @@ class ApiResponse:
     status_code: int = 200
 
     pagination_info: PaginationInfo | None = None
+
+
+def api_file_response(contents: Any, filename: str, content_type: str = "application/octet-stream"):
+    # TODO - probably some sort of logic here for contents to handle large files? Probably should take in a file pointer
+    # rather than the raw bytes.
+    return flask.Response(contents, content_type=content_type, headers={"Content-Disposition": f"attachment; filename={filename}"})
 
 
 def process_marshmallow_issues(marshmallow_issues: dict) -> list[ValidationErrorDetail]:

--- a/api/src/api/schemas/response_schema.py
+++ b/api/src/api/schemas/response_schema.py
@@ -8,14 +8,26 @@ class ValidationIssueSchema(Schema):
     field = fields.String(metadata={"description": "The field that failed"})
 
 
-class BaseResponseSchema(Schema):
+class AbstractResponseSchema(Schema):
     message = fields.String(metadata={"description": "The message to return"})
     data = fields.MixinField(metadata={"description": "The REST resource object"}, dump_default={})
     status_code = fields.Integer(metadata={"description": "The HTTP status code"}, dump_default=200)
 
+class AbstractPaginationResponseSchema(AbstractResponseSchema):
+    pagination_info = fields.Nested(
+        PaginationInfoSchema(),
+        metadata={"description": "The pagination information for paginated endpoints"},
+    )
 
-class ErrorResponseSchema(BaseResponseSchema):
+class BaseResponseSchema(Schema):
+    message = fields.String(metadata={"description": "The message to return"})
+    data = fields.MixinField(metadata={"description": "The REST resource object"}, dump_default={}) # TODO - is this overridable?
+    status_code = fields.Integer(metadata={"description": "The HTTP status code"}, dump_default=200)
+
+
+class ErrorResponseSchema(Schema):
     errors = fields.List(fields.Nested(ValidationIssueSchema()), dump_default=[])
+    status_code = fields.Integer(metadata={"description": "The HTTP status code", "example": 404})
 
 
 class ResponseSchema(BaseResponseSchema):

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -64,7 +64,7 @@ def configure_app(app: APIFlask) -> None:
     # Modify the response schema to instead use the format of our ApiResponse class
     # which adds additional details to the object.
     # https://apiflask.com/schema/#base-response-schema-customization
-    app.config["BASE_RESPONSE_SCHEMA"] = response_schema.ResponseSchema
+    #app.config["BASE_RESPONSE_SCHEMA"] = response_schema.ResponseSchema
     app.config["HTTP_ERROR_SCHEMA"] = response_schema.ErrorResponseSchema
     app.config["VALIDATION_ERROR_SCHEMA"] = response_schema.ErrorResponseSchema
     app.config["SWAGGER_UI_CSS"] = "/static/swagger-ui.min.css"


### PR DESCRIPTION
PROTOTYPE for discussion - will not be merged

## Summary
Fixes #22

### Time to review: __5 mins__

## Changes proposed
Setup an endpoint that returns a presigned S3 URL (as a redirect)

Localstack setup to have a mocked S3

## Context for reviewers
Experimenting with a few ideas about how we handle a download endpoint. The simplest way I can think of is to put the files on S3, and return a presigned URL. Presigned URLs let users directly interact with S3 files, so we aren't actually handling the transfer of files, the users could download it directly from the source in a safe/secure manner.

The exact way we return the URL we can sort out later, while I did set this up as a redirect, I don't think that actually would be what we'd want. I think instead returning the URL in an ordinary response would be better. The frontend (or any users of the endpoint) could then download it in whatever manner they want. 

## Additional information
This is clunky to run, requires a bit of manual work, if you'd like to test this out, let me know and I'll help.

