### PR TITLE
[Issue #88] Adjust docker commands based on recent updates

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -38,7 +38,7 @@ endif
 ifeq "$(PY_RUN_APPROACH)" "local"
 PY_RUN_CMD := poetry run
 else
-PY_RUN_CMD := docker-compose run $(DOCKER_EXEC_ARGS) --rm $(APP_NAME) poetry run
+PY_RUN_CMD := docker compose run $(DOCKER_EXEC_ARGS) --rm $(APP_NAME) poetry run
 endif
 
 FLASK_CMD := $(PY_RUN_CMD) flask
@@ -89,24 +89,24 @@ setup-local:
 ##################################################
 
 build:
-	docker-compose build
+	docker compose build
 
 start:
-	docker-compose up --detach
+	docker compose up --detach
 
 start-debug:
 	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --detach
 
 run-logs: start
-	docker-compose logs --follow --no-color $(APP_NAME)
+	docker compose logs --follow --no-color $(APP_NAME)
 
 init: build init-db init-opensearch
 
 clean-volumes: ## Remove project docker volumes (which includes the DB state)
-	docker-compose down --volumes
+	docker compose down --volumes
 
 stop:
-	docker-compose down
+	docker compose down
 
 check: format-check lint db-check-migrations test
 
@@ -123,7 +123,7 @@ check: format-check lint db-check-migrations test
 init-db: start-db setup-postgres-db db-migrate
 
 start-db:
-	docker-compose up --detach grants-db
+	docker compose up --detach grants-db
 	./bin/wait-for-local-db.sh
 
 ## Destroy current DB, setup new one
@@ -187,8 +187,8 @@ init-opensearch: start-opensearch
 # TODO - in subsequent PRs, we'll add more to this command to setup the search index locally
 
 start-opensearch:
-	docker-compose up --detach opensearch-node
-	docker-compose up --detach opensearch-dashboards
+	docker compose up --detach opensearch-node
+	docker compose up --detach opensearch-dashboards
 	./bin/wait-for-local-opensearch.sh
 
 

--- a/api/README.md
+++ b/api/README.md
@@ -32,7 +32,7 @@ root
 │   └── setup.cfg           Python config for tools that don't support pyproject.toml yet
 │   └── Dockerfile          Docker build file for project
 │
-└── docker-compose.yml  Config file for docker-compose tool, used for local development
+└── docker-compose.yml  Config file for docker compose tool, used for local development
 ```
 
 ## Local Development

--- a/api/docker-compose.debug.yml
+++ b/api/docker-compose.debug.yml
@@ -1,8 +1,5 @@
-version: "3.8"
-
 # run with `docker compose -f`
 # combines ports and env vars with the main docker-compose.yml main-app service
-
 services:
   grants-api:
     command: [

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,7 +1,4 @@
-version: '3'
-
 services:
-
   grants-db:
     image: postgres:15-alpine
     container_name: grants-db

--- a/api/local.env
+++ b/api/local.env
@@ -1,5 +1,5 @@
 # Local environment variables
-# Used by docker-compose and it can be loaded
+# Used by docker compose and it can be loaded
 # by calling load_local_env_vars() from api/src/util/local.py
 
 ENVIRONMENT=local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 include:
   - path: ./api/docker-compose.yml
   - path: ./frontend/docker-compose.yml

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   nextjs:
     container_name: next-dev


### PR DESCRIPTION
## Summary
Fixes #88

### Time to review: __5 mins__

## Changes proposed
Remove the version field from the docker-compose files

Adjust the docker commands to use `docker compose` instead of `docker-compose`

## Context for reviewers
A recent version of docker removed the need for specifying a version in the compose files - so the field is now obsolete and just gives a warning whenever you run a command:
https://docs.docker.com/compose/compose-file/04-version-and-name/

The change in the command we run is actually from 2021 and makes sure we use docker compose v2. Depending on how you've setup your local instance of docker, `docker-compose` may have been aliased to `docker compose` anyways (I actually think if it wasn't, certain things break anyways). This is just using the proper format for certain.

## Additional information
I went through running several docker commands and noticed no difference, as this change shouldn't meaningfully change anything, that is to be expected.

