### PR TITLE
Add Logging to Sprint import

### DIFF
--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -157,6 +157,8 @@ def export_json_to_database(
     issue_file: Annotated[str, ISSUE_FILE_ARG],
 ) -> None:
     """Import JSON data to the database."""
+    logger.info("Beginning import")
+
     # Get the database engine and establish a connection
     engine = db.get_db()
 
@@ -183,6 +185,8 @@ def export_json_to_database(
         engine=engine,
         replace_table=True,
     )
+    rows = len(sprint_data.to_dict())
+    logger.info("Number of rows in table: %s", rows)
 
 
 @metrics_app.command(name="deliverable_percent_complete")


### PR DESCRIPTION
## Summary
Fixes #110 

### Time to review: __1 mins__

## Changes proposed
* added info level logging statement to the `db_import` command

## Context for reviewers
_Terminal_
<img width="1446" alt="Screen Shot 2024-07-01 at 4 35 44 PM" src="https://github.com/navapbc/simpler-grants-gov/assets/37313082/4f1ddf6c-5ae5-45d6-8bc9-229ff47e6b4b">

_Database_
<img width="1148" alt="Screen Shot 2024-07-01 at 4 35 56 PM" src="https://github.com/navapbc/simpler-grants-gov/assets/37313082/99ac5d11-6073-42b2-bffe-32dff78e75f4">

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

