### PR TITLE
[Task 163] Add post_date and close_date filters to search endpoint schema

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -182,6 +182,11 @@ paths:
                       one_of:
                       - forecasted
                       - posted
+                    post_date:
+                      start_date: '2024-01-01'
+                      end_date: '2024-02-01'
+                    close_date:
+                      start_date: '2024-01-01'
                   pagination:
                     order_by: opportunity_id
                     page_offset: 1
@@ -826,6 +831,32 @@ components:
             type: string
             minLength: 2
             example: USAID
+    PostDateFilterV1:
+      type: object
+      properties:
+        start_date:
+          type:
+          - string
+          - 'null'
+          format: date
+        end_date:
+          type:
+          - string
+          - 'null'
+          format: date
+    CloseDateFilterV1:
+      type: object
+      properties:
+        start_date:
+          type:
+          - string
+          - 'null'
+          format: date
+        end_date:
+          type:
+          - string
+          - 'null'
+          format: date
     OpportunitySearchFilterV1:
       type: object
       properties:
@@ -854,6 +885,16 @@ components:
           - object
           allOf:
           - $ref: '#/components/schemas/AgencyFilterV1'
+        post_date:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/PostDateFilterV1'
+        close_date:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/CloseDateFilterV1'
     OpportunityPaginationV1:
       type: object
       properties:

--- a/api/src/api/opportunities_v1/opportunity_routes.py
+++ b/api/src/api/opportunities_v1/opportunity_routes.py
@@ -54,6 +54,13 @@ examples = {
                 "funding_category": {"one_of": ["recovery_act", "arts", "natural_resources"]},
                 "funding_instrument": {"one_of": ["cooperative_agreement", "grant"]},
                 "opportunity_status": {"one_of": ["forecasted", "posted"]},
+                "post_date": {
+                    "start_date": "2024-01-01",
+                    "end_date": "2024-02-01"
+                },
+                "close_date": {
+                    "start_date": "2024-01-01",
+                }
             },
             "pagination": {
                 "order_by": "opportunity_id",

--- a/api/src/api/opportunities_v1/opportunity_routes.py
+++ b/api/src/api/opportunities_v1/opportunity_routes.py
@@ -54,13 +54,10 @@ examples = {
                 "funding_category": {"one_of": ["recovery_act", "arts", "natural_resources"]},
                 "funding_instrument": {"one_of": ["cooperative_agreement", "grant"]},
                 "opportunity_status": {"one_of": ["forecasted", "posted"]},
-                "post_date": {
-                    "start_date": "2024-01-01",
-                    "end_date": "2024-02-01"
-                },
+                "post_date": {"start_date": "2024-01-01", "end_date": "2024-02-01"},
                 "close_date": {
                     "start_date": "2024-01-01",
-                }
+                },
             },
             "pagination": {
                 "order_by": "opportunity_id",

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -321,6 +321,19 @@ class OpportunitySearchFilterV1Schema(Schema):
         .build()
     )
 
+    post_date = fields.Nested(
+        StrSearchSchemaBuilder("PostDateFilterV1Schema")
+        .with_start_date()
+        .with_end_date()
+        .build()
+    )
+
+    close_date = fields.Nested(
+        StrSearchSchemaBuilder("CloseDateFilterV1Schema")
+        .with_start_date()
+        .with_end_date()
+        .build()
+    )
 
 class OpportunityFacetV1Schema(Schema):
     opportunity_status = fields.Dict(

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 
 from src.api.schemas.extension import Schema, fields, validators
 from src.api.schemas.response_schema import AbstractResponseSchema, PaginationMixinSchema
-from src.api.schemas.search_schema import StrSearchSchemaBuilder, DateSearchSchemaBuilder
+from src.api.schemas.search_schema import DateSearchSchemaBuilder, StrSearchSchemaBuilder
 from src.constants.lookup_constants import (
     ApplicantType,
     FundingCategory,
@@ -322,18 +322,13 @@ class OpportunitySearchFilterV1Schema(Schema):
     )
 
     post_date = fields.Nested(
-        DateSearchSchemaBuilder("PostDateFilterV1Schema")
-        .with_start_date()
-        .with_end_date()
-        .build()
+        DateSearchSchemaBuilder("PostDateFilterV1Schema").with_start_date().with_end_date().build()
     )
 
     close_date = fields.Nested(
-        DateSearchSchemaBuilder("CloseDateFilterV1Schema")
-        .with_start_date()
-        .with_end_date()
-        .build()
+        DateSearchSchemaBuilder("CloseDateFilterV1Schema").with_start_date().with_end_date().build()
     )
+
 
 class OpportunityFacetV1Schema(Schema):
     opportunity_status = fields.Dict(

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 
 from src.api.schemas.extension import Schema, fields, validators
 from src.api.schemas.response_schema import AbstractResponseSchema, PaginationMixinSchema
-from src.api.schemas.search_schema import StrSearchSchemaBuilder
+from src.api.schemas.search_schema import StrSearchSchemaBuilder, DateSearchSchemaBuilder
 from src.constants.lookup_constants import (
     ApplicantType,
     FundingCategory,
@@ -322,14 +322,14 @@ class OpportunitySearchFilterV1Schema(Schema):
     )
 
     post_date = fields.Nested(
-        StrSearchSchemaBuilder("PostDateFilterV1Schema")
+        DateSearchSchemaBuilder("PostDateFilterV1Schema")
         .with_start_date()
         .with_end_date()
         .build()
     )
 
     close_date = fields.Nested(
-        StrSearchSchemaBuilder("CloseDateFilterV1Schema")
+        DateSearchSchemaBuilder("CloseDateFilterV1Schema")
         .with_start_date()
         .with_end_date()
         .build()

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -80,9 +80,6 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
             )
     """
 
-    def __init__(self, schema_class_name: str):
-        super().__init__(schema_class_name)
-
     def with_one_of(
         self,
         *,
@@ -110,9 +107,6 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
         self.schema_fields["one_of"] = fields.List(list_type, validate=[validators.Length(min=1)])
 
         return self
-
-    def build(self) -> Schema:
-        return super().build()
 
 
 class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
@@ -155,9 +149,6 @@ class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
         )
     """
 
-    def __init__(self, schema_class_name: str):
-        super().__init__(schema_class_name)
-
     def with_start_date(self) -> "DateSearchSchemaBuilder":
         self.schema_fields["start_date"] = fields.Date(allow_none=True)
         return self
@@ -165,6 +156,3 @@ class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
     def with_end_date(self) -> "DateSearchSchemaBuilder":
         self.schema_fields["end_date"] = fields.Date(allow_none=True)
         return self
-
-    def build(self) -> Schema:
-        return super().build()

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -34,6 +34,7 @@ class BaseSearchSchema(Schema):
                 ]
             )
 
+
 class BaseSearchSchemaBuilder:
     def __init__(self, schema_class_name: str):
         # The schema class name is used on the endpoint
@@ -42,6 +43,7 @@ class BaseSearchSchemaBuilder:
 
     def build(self) -> Schema:
         return BaseSearchSchema.from_dict(self.schema_fields, name=self.schema_class_name)  # type: ignore
+
 
 class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
     """
@@ -77,6 +79,7 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
                     .build()
             )
     """
+
     def __init__(self, schema_class_name: str):
         super().__init__(schema_class_name)
 
@@ -110,6 +113,7 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
 
     def build(self) -> Schema:
         return super().build()
+
 
 class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
     """
@@ -150,14 +154,15 @@ class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
                 .build()
         )
     """
+
     def __init__(self, schema_class_name: str):
         super().__init__(schema_class_name)
 
-    def with_start_date(self) -> "StrSearchSchemaBuilder":
+    def with_start_date(self) -> "DateSearchSchemaBuilder":
         self.schema_fields["start_date"] = fields.Date(allow_none=True)
         return self
 
-    def with_end_date(self) -> "StrSearchSchemaBuilder":
+    def with_end_date(self) -> "DateSearchSchemaBuilder":
         self.schema_fields["end_date"] = fields.Date(allow_none=True)
         return self
 

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -50,7 +50,8 @@ class StrSearchSchemaBuilder:
         }
 
     This helps generate the filters for a given field. At the moment,
-    only a one_of filter is implemented.
+    only a one_of filter is implemented. Support for start_date and
+    end_date filters have been partially implemented.
 
     Usage::
 
@@ -66,6 +67,25 @@ class StrSearchSchemaBuilder:
             example_str_field = fields.Nested(
                 StrSearchSchemaBuilder("ExampleStrFieldSchema")
                     .with_one_of(example="example_value", minimum_length=5)
+                    .build()
+            )
+
+            example_start_date_field = fields.Nested(
+                StrSearchSchemaBuilder("ExampleStartDateFieldSchema")
+                    .with_start_date()
+                    .build()
+            )
+
+            example_end_date_field = fields.Nested(
+                StrSearchSchemaBuilder("ExampleEndDateFieldSchema")
+                    .with_end_date()
+                    .build()
+            )
+
+            example_startend_date_field = fields.Nested(
+                StrSearchSchemaBuilder("ExampleStartEndDateFieldSchema")
+                    .with_start_date()
+                    .with_end_date()
                     .build()
             )
     """
@@ -101,6 +121,14 @@ class StrSearchSchemaBuilder:
         # Note that the list requires at least one value (sending us just [] will raise a validation error)
         self.schema_fields["one_of"] = fields.List(list_type, validate=[validators.Length(min=1)])
 
+        return self
+    
+    def with_start_date(self) -> "StrSearchSchemaBuilder":
+        self.schema_fields["start_date"] = fields.Date(allow_none=True)
+        return self
+    
+    def with_end_date(self) -> "StrSearchSchemaBuilder":
+        self.schema_fields["end_date"] = fields.Date(allow_none=True)
         return self
 
     def build(self) -> Schema:

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -111,7 +111,7 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
 
 class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
     """
-    Builder for setting up a filter for a date in the search endpoint schema.
+    Builder for setting up a filter for a range of dates in the search endpoint schema.
 
     Example of what this might look like:
         {
@@ -130,19 +130,19 @@ class DateSearchSchemaBuilder(BaseSearchSchemaBuilder):
     # In a search request schema, you would use it like so:
 
         example_start_date_field = fields.Nested(
-            StrSearchSchemaBuilder("ExampleStartDateFieldSchema")
+            DateSearchSchemaBuilder("ExampleStartDateFieldSchema")
                 .with_start_date()
                 .build()
         )
 
         example_end_date_field = fields.Nested(
-            StrSearchSchemaBuilder("ExampleEndDateFieldSchema")
+            DateSearchSchemaBuilder("ExampleEndDateFieldSchema")
                 .with_end_date()
                 .build()
         )
 
         example_startend_date_field = fields.Nested(
-            StrSearchSchemaBuilder("ExampleStartEndDateFieldSchema")
+            DateSearchSchemaBuilder("ExampleStartEndDateFieldSchema")
                 .with_start_date()
                 .with_end_date()
                 .build()

--- a/api/tests/src/api/opportunities_v1/conftest.py
+++ b/api/tests/src/api/opportunities_v1/conftest.py
@@ -37,6 +37,8 @@ def get_search_request(
     applicant_type_one_of: list[ApplicantType] | None = None,
     opportunity_status_one_of: list[OpportunityStatus] | None = None,
     agency_one_of: list[str] | None = None,
+    post_date: dict | None = None,
+    close_date: dict | None = None,
     format: str | None = None,
 ):
     req = {
@@ -64,6 +66,12 @@ def get_search_request(
 
     if agency_one_of is not None:
         filters["agency"] = {"one_of": agency_one_of}
+    
+    if post_date is not None:
+        filters["post_date"] = post_date
+    
+    if close_date is not None:
+        filters["close_date"] = close_date
 
     if len(filters) > 0:
         req["filters"] = filters

--- a/api/tests/src/api/opportunities_v1/conftest.py
+++ b/api/tests/src/api/opportunities_v1/conftest.py
@@ -66,10 +66,10 @@ def get_search_request(
 
     if agency_one_of is not None:
         filters["agency"] = {"one_of": agency_one_of}
-    
+
     if post_date is not None:
         filters["post_date"] = post_date
-    
+
     if close_date is not None:
         filters["close_date"] = close_date
 

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -723,7 +723,14 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(post_date={"start_date": None, "end_date": "2020-02-01"}), 200),
             (get_search_request(post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
             (get_search_request(post_date={"start_date": "I am not a date"}), 422),
+            (get_search_request(post_date={"start_date": "123-456-789"}), 422),
+            (get_search_request(post_date={"start_date": "5"}), 422),
+            (get_search_request(post_date={"start_date": 5}), 422),
             (get_search_request(post_date={"end_date": "I am not a date"}), 422),
+            (get_search_request(post_date={"end_date": "123-456-789"}), 422),
+            (get_search_request(post_date={"end_date": "5"}), 422),
+            (get_search_request(post_date={"end_date": 5}), 422),
+
             # Close Date
             (get_search_request(close_date={"start_date": None}), 200),
             (get_search_request(close_date={"end_date": None}), 200),

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -711,67 +711,67 @@ class TestOpportunityRouteSearch(BaseTestClass):
         call_search_and_validate(client, api_auth_token, search_request, expected_results)
 
     @pytest.mark.parametrize(
-        "search_request, expected_status_code",
+        "search_request",
         [
             # Post Date
-            (get_search_request(post_date={"start_date": None}), 200),
-            (get_search_request(post_date={"end_date": None}), 200),
-            (get_search_request(post_date={"start_date": "2020-01-01"}), 200),
-            (get_search_request(post_date={"end_date": "2020-02-01"}), 200),
-            (get_search_request(post_date={"start_date": None, "end_date": None}), 200),
-            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": None}), 200),
-            (get_search_request(post_date={"start_date": None, "end_date": "2020-02-01"}), 200),
-            (
-                get_search_request(
-                    post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}
-                ),
-                200,
-            ),
-            (get_search_request(post_date={"start_date": "I am not a date"}), 422),
-            (get_search_request(post_date={"start_date": "123-456-789"}), 422),
-            (get_search_request(post_date={"start_date": "5"}), 422),
-            (get_search_request(post_date={"start_date": 5}), 422),
-            (get_search_request(post_date={"end_date": "I am not a date"}), 422),
-            (get_search_request(post_date={"end_date": "123-456-789"}), 422),
-            (get_search_request(post_date={"end_date": "5"}), 422),
-            (get_search_request(post_date={"end_date": 5}), 422),
+            (get_search_request(post_date={"start_date": None})),
+            (get_search_request(post_date={"end_date": None})),
+            (get_search_request(post_date={"start_date": "2020-01-01"})),
+            (get_search_request(post_date={"end_date": "2020-02-01"})),
+            (get_search_request(post_date={"start_date": None, "end_date": None})),
+            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": None})),
+            (get_search_request(post_date={"start_date": None, "end_date": "2020-02-01"})),
+            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"})),
             # Close Date
-            (get_search_request(close_date={"start_date": None}), 200),
-            (get_search_request(close_date={"end_date": None}), 200),
-            (get_search_request(close_date={"start_date": "2020-01-01"}), 200),
-            (get_search_request(close_date={"end_date": "2020-02-01"}), 200),
-            (get_search_request(close_date={"start_date": None, "end_date": None}), 200),
-            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": None}), 200),
-            (get_search_request(close_date={"start_date": None, "end_date": "2020-02-01"}), 200),
-            (
-                get_search_request(
-                    close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}
-                ),
-                200,
-            ),
-            (get_search_request(close_date={"start_date": "I am not a date"}), 422),
-            (get_search_request(close_date={"start_date": "123-456-789"}), 422),
-            (get_search_request(close_date={"start_date": "5"}), 422),
-            (get_search_request(close_date={"start_date": 5}), 422),
-            (get_search_request(close_date={"end_date": "I am not a date"}), 422),
-            (get_search_request(close_date={"end_date": "123-456-789"}), 422),
-            (get_search_request(close_date={"end_date": "5"}), 422),
-            (get_search_request(close_date={"end_date": 5}), 422),
+            (get_search_request(close_date={"start_date": None})),
+            (get_search_request(close_date={"end_date": None})),
+            (get_search_request(close_date={"start_date": "2020-01-01"})),
+            (get_search_request(close_date={"end_date": "2020-02-01"})),
+            (get_search_request(close_date={"start_date": None, "end_date": None})),
+            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": None})),
+            (get_search_request(close_date={"start_date": None, "end_date": "2020-02-01"})),
+            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"})),
         ],
     )
-    def test_search_validate_date_filters(
-        self, client, api_auth_token, search_request, expected_status_code
-    ):
+    def test_search_validate_date_filters_200(self, client, api_auth_token, search_request):
         resp = client.post(
             "/v1/opportunities/search", json=search_request, headers={"X-Auth": api_auth_token}
         )
-        assert resp.status_code == expected_status_code
+        assert resp.status_code == 200
 
-        if resp.status_code == 422:
-            json = resp.get_json()
-            error = json["errors"][0]
-            assert json["message"] == "Validation error"
-            assert error["message"] == "Not a valid date."
+    @pytest.mark.parametrize(
+        "search_request",
+        [
+            # Post Date
+            (get_search_request(post_date={"start_date": "I am not a date"})),
+            (get_search_request(post_date={"start_date": "123-456-789"})),
+            (get_search_request(post_date={"start_date": "5"})),
+            (get_search_request(post_date={"start_date": 5})),
+            (get_search_request(post_date={"end_date": "I am not a date"})),
+            (get_search_request(post_date={"end_date": "123-456-789"})),
+            (get_search_request(post_date={"end_date": "5"})),
+            (get_search_request(post_date={"end_date": 5})),
+            # Close Date
+            (get_search_request(close_date={"start_date": "I am not a date"})),
+            (get_search_request(close_date={"start_date": "123-456-789"})),
+            (get_search_request(close_date={"start_date": "5"})),
+            (get_search_request(close_date={"start_date": 5})),
+            (get_search_request(close_date={"end_date": "I am not a date"})),
+            (get_search_request(close_date={"end_date": "123-456-789"})),
+            (get_search_request(close_date={"end_date": "5"})),
+            (get_search_request(close_date={"end_date": 5})),
+        ],
+    )
+    def test_search_validate_date_filters_422(self, client, api_auth_token, search_request):
+        resp = client.post(
+            "/v1/opportunities/search", json=search_request, headers={"X-Auth": api_auth_token}
+        )
+        assert resp.status_code == 422
+
+        json = resp.get_json()
+        error = json["errors"][0]
+        assert json["message"] == "Validation error"
+        assert error["message"] == "Not a valid date."
 
     @pytest.mark.parametrize(
         "search_request, expected_results",

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -721,7 +721,12 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(post_date={"start_date": None, "end_date": None}), 200),
             (get_search_request(post_date={"start_date": "2020-01-01", "end_date": None}), 200),
             (get_search_request(post_date={"start_date": None, "end_date": "2020-02-01"}), 200),
-            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
+            (
+                get_search_request(
+                    post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}
+                ),
+                200,
+            ),
             (get_search_request(post_date={"start_date": "I am not a date"}), 422),
             (get_search_request(post_date={"start_date": "123-456-789"}), 422),
             (get_search_request(post_date={"start_date": "5"}), 422),
@@ -730,7 +735,6 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(post_date={"end_date": "123-456-789"}), 422),
             (get_search_request(post_date={"end_date": "5"}), 422),
             (get_search_request(post_date={"end_date": 5}), 422),
-
             # Close Date
             (get_search_request(close_date={"start_date": None}), 200),
             (get_search_request(close_date={"end_date": None}), 200),
@@ -739,7 +743,12 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(close_date={"start_date": None, "end_date": None}), 200),
             (get_search_request(close_date={"start_date": "2020-01-01", "end_date": None}), 200),
             (get_search_request(close_date={"start_date": None, "end_date": "2020-02-01"}), 200),
-            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
+            (
+                get_search_request(
+                    close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}
+                ),
+                200,
+            ),
             (get_search_request(close_date={"start_date": "I am not a date"}), 422),
             (get_search_request(close_date={"start_date": "123-456-789"}), 422),
             (get_search_request(close_date={"start_date": "5"}), 422),
@@ -748,7 +757,7 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(close_date={"end_date": "123-456-789"}), 422),
             (get_search_request(close_date={"end_date": "5"}), 422),
             (get_search_request(close_date={"end_date": 5}), 422),
-        ]
+        ],
     )
     def test_search_validate_date_filters(
         self, client, api_auth_token, search_request, expected_status_code

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -711,6 +711,47 @@ class TestOpportunityRouteSearch(BaseTestClass):
         call_search_and_validate(client, api_auth_token, search_request, expected_results)
 
     @pytest.mark.parametrize(
+        "search_request, expected_status_code",
+        [
+            # Post Date
+            (get_search_request(post_date={"start_date": None}), 200),
+            (get_search_request(post_date={"end_date": None}), 200),
+            (get_search_request(post_date={"start_date": "2020-01-01"}), 200),
+            (get_search_request(post_date={"end_date": "2020-02-01"}), 200),
+            (get_search_request(post_date={"start_date": None, "end_date": None}), 200),
+            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": None}), 200),
+            (get_search_request(post_date={"start_date": None, "end_date": "2020-02-01"}), 200),
+            (get_search_request(post_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
+            (get_search_request(post_date={"start_date": "I am not a date"}), 422),
+            (get_search_request(post_date={"end_date": "I am not a date"}), 422),
+            # Close Date
+            (get_search_request(close_date={"start_date": None}), 200),
+            (get_search_request(close_date={"end_date": None}), 200),
+            (get_search_request(close_date={"start_date": "2020-01-01"}), 200),
+            (get_search_request(close_date={"end_date": "2020-02-01"}), 200),
+            (get_search_request(close_date={"start_date": None, "end_date": None}), 200),
+            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": None}), 200),
+            (get_search_request(close_date={"start_date": None, "end_date": "2020-02-01"}), 200),
+            (get_search_request(close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
+            (get_search_request(close_date={"start_date": "I am not a date"}), 422),
+            (get_search_request(close_date={"end_date": "I am not a date"}), 422)
+        ]
+    )
+    def test_search_validate_date_filters(
+        self, client, api_auth_token, search_request, expected_status_code
+    ):
+        resp = client.post(
+            "/v1/opportunities/search", json=search_request, headers={"X-Auth": api_auth_token}
+        )
+        assert resp.status_code == expected_status_code
+
+        if resp.status_code == 422:
+            json = resp.get_json()
+            error = json["errors"][0]
+            assert json["message"] == "Validation error"
+            assert error["message"] == "Not a valid date."
+
+    @pytest.mark.parametrize(
         "search_request, expected_results",
         [
             # Note that the sorting is not relevancy for this as we intend to update the relevancy scores a bit

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -741,7 +741,13 @@ class TestOpportunityRouteSearch(BaseTestClass):
             (get_search_request(close_date={"start_date": None, "end_date": "2020-02-01"}), 200),
             (get_search_request(close_date={"start_date": "2020-01-01", "end_date": "2020-02-01"}), 200),
             (get_search_request(close_date={"start_date": "I am not a date"}), 422),
-            (get_search_request(close_date={"end_date": "I am not a date"}), 422)
+            (get_search_request(close_date={"start_date": "123-456-789"}), 422),
+            (get_search_request(close_date={"start_date": "5"}), 422),
+            (get_search_request(close_date={"start_date": 5}), 422),
+            (get_search_request(close_date={"end_date": "I am not a date"}), 422),
+            (get_search_request(close_date={"end_date": "123-456-789"}), 422),
+            (get_search_request(close_date={"end_date": "5"}), 422),
+            (get_search_request(close_date={"end_date": 5}), 422),
         ]
     )
     def test_search_validate_date_filters(


### PR DESCRIPTION
## Summary
Fixes #163 

### Time to review: 15 mins

## Changes proposed
- Added .with_start_date to search_schema builder to allow building a date field with key of "start_date"
- Added .with_end_date to search_schema builder to allow building a date field with key of "end_date"
- Added post_date and close_date properties to OpportunitySearchFilterV1Schema class, which utilize the above to build schema filters for post_date and close_date which can utilize start_date and/or end_date fields.
- Added two unit tests in test_opportunity_route_search that will test the data validation of these new filters. One test is for 200 response cases and the other test is for 422 (invalid) response cases.

## Context for reviewers
Note: As noted in the AC of Issue #163, this PR does NOT include implementation of the filters. Currently, these filters do nothing as they haven't been tied to any sort of query. This PR is just to lay the ground work.
