### PR TITLE
[Issue #170] Remove inline styling from pagination wrapper component

### DIFF
--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -41,9 +41,7 @@ export default function SearchPagination({
   };
 
   return (
-    <div
-      className={`grants-pagination ${loading ? 'disabled' : ''}`}
-    >
+    <div className={`grants-pagination ${loading ? "disabled" : ""}`}>
       <Pagination
         pathname="/search"
         totalPages={pages}

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -42,10 +42,7 @@ export default function SearchPagination({
 
   return (
     <div
-      style={{
-        pointerEvents: loading ? "none" : "fill",
-        opacity: loading ? 0.5 : 1,
-      }}
+      className={`grants-pagination ${loading ? 'disabled' : ''}`}
     >
       <Pagination
         pathname="/search"

--- a/frontend/src/styles/_loading.scss
+++ b/frontend/src/styles/_loading.scss
@@ -49,3 +49,14 @@ $spinner-size: units(4);
     transform: rotate(360deg);
   }
 }
+
+.grants-pagination.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  & > *, & * {
+    user-select:none;
+    pointer-events:none;
+  }
+}
+
+

--- a/frontend/src/styles/_loading.scss
+++ b/frontend/src/styles/_loading.scss
@@ -53,10 +53,9 @@ $spinner-size: units(4);
 .grants-pagination.disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  & > *, & * {
-    user-select:none;
-    pointer-events:none;
+  & > *,
+  & * {
+    user-select: none;
+    pointer-events: none;
   }
 }
-
-


### PR DESCRIPTION
## Summary
Fixes #170 

### Time to review: __2 mins__

## Changes proposed
> Removed inline styling on component

## Context for reviewers
> Ended up having to create a custom loading style for pagination due to no support from USWDS on this. Honestly though IDK why we don't just hide pagination during loading...

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
![2024-08-08 13 59 02](https://github.com/user-attachments/assets/04994a3f-a48e-4511-839d-aa686a7f1414)

