### PR TITLE
[Issue #174] Hide pagination component if no results are found

### DIFF
--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -47,17 +47,19 @@ export default function SearchPagination({
         opacity: loading ? 0.5 : 1,
       }}
     >
-      <Pagination
-        pathname="/search"
-        totalPages={pages}
-        currentPage={page}
-        maxSlots={MAX_SLOTS}
-        onClickNext={() => updatePage(page + 1)}
-        onClickPrevious={() => updatePage(page > 1 ? page - 1 : 0)}
-        onClickPageNumber={(event: React.MouseEvent, page: number) =>
-          updatePage(page)
-        }
-      />
+      {pages > 0 && (
+        <Pagination
+          pathname="/search"
+          totalPages={pages}
+          currentPage={page}
+          maxSlots={MAX_SLOTS}
+          onClickNext={() => updatePage(page + 1)}
+          onClickPrevious={() => updatePage(page > 1 ? page - 1 : 0)}
+          onClickPageNumber={(event: React.MouseEvent, page: number) =>
+            updatePage(page)
+          }
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -35,11 +35,9 @@ export default function SearchPagination({
   const pages = total || Number(totalPages);
 
   const updatePage = (page: number) => {
-    console.log("here");
     updateTotalPages(String(total));
     updateTotalResults(totalResults);
     updateQueryParams(String(page), "page", query, scroll);
-    console.log("here2");
   };
 
   return (

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -35,9 +35,11 @@ export default function SearchPagination({
   const pages = total || Number(totalPages);
 
   const updatePage = (page: number) => {
+    console.log("here");
     updateTotalPages(String(total));
     updateTotalResults(totalResults);
     updateQueryParams(String(page), "page", query, scroll);
+    console.log("here2");
   };
 
   return (

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -45,16 +45,17 @@ export default function SearchPagination({
   return (
     <div className={`grants-pagination ${loading ? "disabled" : ""}`}>
       {pages > 0 && (
-      <Pagination
-        pathname="/search"
-        totalPages={pages}
-        currentPage={page}
-        maxSlots={MAX_SLOTS}
-        onClickNext={() => updatePage(page + 1)}
-        onClickPrevious={() => updatePage(page > 1 ? page - 1 : 0)}
-        onClickPageNumber={(event: React.MouseEvent, page: number) =>
-          updatePage(page)}
-      />
+        <Pagination
+          pathname="/search"
+          totalPages={pages}
+          currentPage={page}
+          maxSlots={MAX_SLOTS}
+          onClickNext={() => updatePage(page + 1)}
+          onClickPrevious={() => updatePage(page > 1 ? page - 1 : 0)}
+          onClickPageNumber={(event: React.MouseEvent, page: number) =>
+            updatePage(page)
+          }
+        />
       )}
     </div>
   );

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -53,9 +53,9 @@ export default function SearchPagination({
         onClickNext={() => updatePage(page + 1)}
         onClickPrevious={() => updatePage(page > 1 ? page - 1 : 0)}
         onClickPageNumber={(event: React.MouseEvent, page: number) =>
-          updatePage(page)
-        }
+          updatePage(page)}
       />
+      )}
     </div>
   );
 }

--- a/frontend/tests/components/search/SearchPagination.test.tsx
+++ b/frontend/tests/components/search/SearchPagination.test.tsx
@@ -19,7 +19,7 @@ const mockUpdateTotalResults = jest.fn();
 interface SearchPaginationProps {
   page: number;
   query: string;
-  total?: number;
+  total?: string;
   loading?: boolean;
 }
 

--- a/frontend/tests/components/search/SearchPagination.test.tsx
+++ b/frontend/tests/components/search/SearchPagination.test.tsx
@@ -19,7 +19,7 @@ const mockUpdateTotalResults = jest.fn();
 interface SearchPaginationProps {
   page: number;
   query: string;
-  total?: string;
+  total?: number | null;
   loading?: boolean;
 }
 

--- a/frontend/tests/components/search/SearchPagination.test.tsx
+++ b/frontend/tests/components/search/SearchPagination.test.tsx
@@ -12,12 +12,9 @@ jest.mock("src/hooks/useSearchParamUpdater", () => ({
   }),
 }));
 
-
 beforeEach(() => {
   jest.clearAllMocks();
 });
-
-
 
 describe("SearchPagination", () => {
   beforeEach(() => {
@@ -46,4 +43,4 @@ describe("SearchPagination", () => {
 
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
   });
-  });
+});

--- a/frontend/tests/components/search/SearchPagination.test.tsx
+++ b/frontend/tests/components/search/SearchPagination.test.tsx
@@ -3,7 +3,6 @@ import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import React from "react";
-import { QueryContext } from "src/app/[locale]/search/QueryProvider";
 import SearchPagination from "src/components/search/SearchPagination";
 
 // Mock the useSearchParamUpdater hook
@@ -13,33 +12,12 @@ jest.mock("src/hooks/useSearchParamUpdater", () => ({
   }),
 }));
 
-const mockUpdateTotalPages = jest.fn();
-const mockUpdateTotalResults = jest.fn();
-
-interface SearchPaginationProps {
-  page: number;
-  query: string;
-  total?: number | null;
-  loading?: boolean;
-}
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const renderComponent = (props: SearchPaginationProps) => {
-  return render(
-    <QueryContext.Provider
-      value={{
-        updateTotalPages: mockUpdateTotalPages,
-        updateTotalResults: mockUpdateTotalResults,
-        totalPages: props.total || 1,
-      }}
-    >
-      <SearchPagination {...props} />
-    </QueryContext.Provider>,
-  );
-};
+
 
 describe("SearchPagination", () => {
   beforeEach(() => {
@@ -68,16 +46,4 @@ describe("SearchPagination", () => {
 
     expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
   });
-  it("disables pagination when loading", () => {
-    renderComponent({
-      page: 1,
-      query: "test",
-      total: 5,
-      loading: true,
-    });
-    expect(screen.getByText("Next").closest("div")).toHaveStyle(
-      "pointer-events: none",
-    );
-    expect(screen.getByText("Next").closest("div")).toHaveStyle("opacity: 0.5");
   });
-});


### PR DESCRIPTION
## Summary
Fixes #174 

### Time to review: __8 mins__

## Changes proposed
> Updated pagination component to hide if there are no results. Previously it would show 7 pages that you could navigate between, all with no results.

## Context for reviewers
Updated all unit tests for pagination component. They were broken and commented out previously.

## Additional information
![2024-08-08 15 45 10](https://github.com/user-attachments/assets/27e8dc6a-dddd-4c52-8086-4cd4579d73fe)


