### PR TITLE
[Issue #179] Incrementally load search data

### DIFF
--- a/api/src/adapters/search/opensearch_client.py
+++ b/api/src/adapters/search/opensearch_client.py
@@ -129,6 +129,15 @@ class SearchClient:
         )
         self._client.bulk(index=index_name, body=bulk_operations, refresh=refresh)
 
+    def index_exists(self, index_name: str) -> bool:
+        # Check if an index OR alias exists by a given name
+        return self._client.indices.exists(index_name)
+
+    def alias_exists(self, alias_name: str) -> bool:
+        # Check if an alias exists
+        existing_index_mapping = self._client.cat.aliases(alias_name, format="json")
+        return len(existing_index_mapping) > 0
+
     def swap_alias_index(
         self, index_name: str, alias_name: str, *, delete_prior_indexes: bool = False
     ) -> None:

--- a/api/src/adapters/search/opensearch_response.py
+++ b/api/src/adapters/search/opensearch_response.py
@@ -10,6 +10,8 @@ class SearchResponse:
 
     aggregations: dict[str, dict[str, int]]
 
+    scroll_id: str | None
+
     @classmethod
     def from_opensearch_response(
         cls, raw_json: dict[str, typing.Any], include_scores: bool = True
@@ -40,6 +42,8 @@ class SearchResponse:
             ]
         }
         """
+        scroll_id = raw_json.get("_scroll_id", None)
+
         hits = raw_json.get("hits", {})
         hits_total = hits.get("total", {})
         total_records = hits_total.get("value", 0)
@@ -59,7 +63,7 @@ class SearchResponse:
         raw_aggs: dict[str, dict[str, typing.Any]] = raw_json.get("aggregations", {})
         aggregations = _parse_aggregations(raw_aggs)
 
-        return cls(total_records, records, aggregations)
+        return cls(total_records, records, aggregations, scroll_id)
 
 
 def _parse_aggregations(

--- a/api/src/search/backend/load_search_data.py
+++ b/api/src/search/backend/load_search_data.py
@@ -1,3 +1,5 @@
+import click
+
 import src.adapters.db as db
 import src.adapters.search as search
 from src.adapters.db import flask_db
@@ -8,8 +10,13 @@ from src.search.backend.load_search_data_blueprint import load_search_data_bluep
 @load_search_data_blueprint.cli.command(
     "load-opportunity-data", help="Load opportunity data from our database to the search index"
 )
+@click.option(
+    "--full-refresh/--incremental",
+    default=True,
+    help="Whether to run a full refresh, or only incrementally update oppportunities",
+)
 @flask_db.with_db_session()
-def load_opportunity_data(db_session: db.Session) -> None:
+def load_opportunity_data(db_session: db.Session, full_refresh: bool) -> None:
     search_client = search.SearchClient()
 
-    LoadOpportunitiesToIndex(db_session, search_client).run()
+    LoadOpportunitiesToIndex(db_session, search_client, full_refresh).run()

--- a/api/tests/src/adapters/search/test_opensearch_client.py
+++ b/api/tests/src/adapters/search/test_opensearch_client.py
@@ -122,6 +122,53 @@ def test_swap_alias_index(search_client, generic_index):
     assert search_client._client.indices.exists(tmp_index) is False
 
 
+def test_index_or_alias_exists(search_client, generic_index):
+    # Create a few aliased indexes
+    index_a = f"test-index-a-{uuid.uuid4().int}"
+    index_b = f"test-index-b-{uuid.uuid4().int}"
+    index_c = f"test-index-c-{uuid.uuid4().int}"
+
+    search_client.create_index(index_a)
+    search_client.create_index(index_b)
+    search_client.create_index(index_c)
+
+    alias_index_a = f"test-alias-a-{uuid.uuid4().int}"
+    alias_index_b = f"test-alias-b-{uuid.uuid4().int}"
+    alias_index_c = f"test-alias-c-{uuid.uuid4().int}"
+
+    search_client.swap_alias_index(index_a, alias_index_a)
+    search_client.swap_alias_index(index_b, alias_index_b)
+    search_client.swap_alias_index(index_c, alias_index_c)
+
+    # Checking the indexes directly - we expect the index method to return true
+    # and the alias method to not
+    assert search_client.index_exists(index_a) is True
+    assert search_client.index_exists(index_b) is True
+    assert search_client.index_exists(index_c) is True
+
+    assert search_client.alias_exists(index_a) is False
+    assert search_client.alias_exists(index_b) is False
+    assert search_client.alias_exists(index_c) is False
+
+    # We just created these aliases, they should exist
+    assert search_client.index_exists(alias_index_a) is True
+    assert search_client.index_exists(alias_index_b) is True
+    assert search_client.index_exists(alias_index_c) is True
+
+    assert search_client.alias_exists(alias_index_a) is True
+    assert search_client.alias_exists(alias_index_b) is True
+    assert search_client.alias_exists(alias_index_c) is True
+
+    # Other random things won't be found for either case
+    assert search_client.index_exists("test-index-a") is False
+    assert search_client.index_exists("asdasdasd") is False
+    assert search_client.index_exists(alias_index_a + "-other") is False
+
+    assert search_client.alias_exists("test-index-a") is False
+    assert search_client.alias_exists("asdasdasd") is False
+    assert search_client.alias_exists(alias_index_a + "-other") is False
+
+
 def test_scroll(search_client, generic_index):
     records = [
         {"id": 1, "title": "Green Eggs & Ham", "notes": "why are the eggs green?"},

--- a/api/tests/src/search/backend/test_load_opportunities_to_index.py
+++ b/api/tests/src/search/backend/test_load_opportunities_to_index.py
@@ -103,7 +103,6 @@ class TestLoadOpportunitiesToIndexPartialRefresh(BaseTestClass):
         opportunity_index_alias,
         load_opportunities_to_index,
     ):
-        # TODO - need to test/modify logic to be better about handling not already having an index
         index_name = "partial-refresh-index-" + get_now_us_eastern_datetime().strftime(
             "%Y-%m-%d_%H-%M-%S"
         )
@@ -141,3 +140,14 @@ class TestLoadOpportunitiesToIndexPartialRefresh(BaseTestClass):
 
         resp = search_client.search(opportunity_index_alias, {"size": 100})
         assert resp.total_records == len(opportunities)
+
+    def test_load_opportunities_to_index_index_does_not_exist(self, db_session, search_client):
+        config = LoadOpportunitiesToIndexConfig(
+            alias_name="fake-index-that-will-not-exist", index_prefix="test-load-opps"
+        )
+        load_opportunities_to_index = LoadOpportunitiesToIndex(
+            db_session, search_client, False, config
+        )
+
+        with pytest.raises(RuntimeError, match="please run the full refresh job"):
+            load_opportunities_to_index.run()

--- a/api/tests/src/search/backend/test_load_opportunities_to_index.py
+++ b/api/tests/src/search/backend/test_load_opportunities_to_index.py
@@ -4,17 +4,18 @@ from src.search.backend.load_opportunities_to_index import (
     LoadOpportunitiesToIndex,
     LoadOpportunitiesToIndexConfig,
 )
+from src.util.datetime_util import get_now_us_eastern_datetime
 from tests.conftest import BaseTestClass
 from tests.src.db.models.factories import OpportunityFactory
 
 
-class TestLoadOpportunitiesToIndex(BaseTestClass):
+class TestLoadOpportunitiesToIndexFullRefresh(BaseTestClass):
     @pytest.fixture(scope="class")
     def load_opportunities_to_index(self, db_session, search_client, opportunity_index_alias):
         config = LoadOpportunitiesToIndexConfig(
             alias_name=opportunity_index_alias, index_prefix="test-load-opps"
         )
-        return LoadOpportunitiesToIndex(db_session, search_client, config)
+        return LoadOpportunitiesToIndex(db_session, search_client, True, config)
 
     def test_load_opportunities_to_index(
         self,
@@ -83,3 +84,60 @@ class TestLoadOpportunitiesToIndex(BaseTestClass):
         assert set([opp.opportunity_id for opp in opportunities]) == set(
             [record["opportunity_id"] for record in resp.records]
         )
+
+
+class TestLoadOpportunitiesToIndexPartialRefresh(BaseTestClass):
+    @pytest.fixture(scope="class")
+    def load_opportunities_to_index(self, db_session, search_client, opportunity_index_alias):
+        config = LoadOpportunitiesToIndexConfig(
+            alias_name=opportunity_index_alias, index_prefix="test-load-opps"
+        )
+        return LoadOpportunitiesToIndex(db_session, search_client, False, config)
+
+    def test_load_opportunities_to_index(
+        self,
+        truncate_opportunities,
+        enable_factory_create,
+        db_session,
+        search_client,
+        opportunity_index_alias,
+        load_opportunities_to_index,
+    ):
+        # TODO - need to test/modify logic to be better about handling not already having an index
+        index_name = "partial-refresh-index-" + get_now_us_eastern_datetime().strftime(
+            "%Y-%m-%d_%H-%M-%S"
+        )
+        search_client.create_index(index_name)
+        search_client.swap_alias_index(
+            index_name, load_opportunities_to_index.config.alias_name, delete_prior_indexes=True
+        )
+
+        # Load a bunch of records into the DB
+        opportunities = []
+        opportunities.extend(OpportunityFactory.create_batch(size=6, is_posted_summary=True))
+        opportunities.extend(OpportunityFactory.create_batch(size=3, is_forecasted_summary=True))
+        opportunities.extend(OpportunityFactory.create_batch(size=2, is_closed_summary=True))
+        opportunities.extend(
+            OpportunityFactory.create_batch(size=8, is_archived_non_forecast_summary=True)
+        )
+        opportunities.extend(
+            OpportunityFactory.create_batch(size=6, is_archived_forecast_summary=True)
+        )
+
+        load_opportunities_to_index.run()
+
+        resp = search_client.search(opportunity_index_alias, {"size": 100})
+        assert resp.total_records == len(opportunities)
+
+        # Add a few more opportunities that will be created
+        opportunities.extend(OpportunityFactory.create_batch(size=3, is_posted_summary=True))
+
+        # Delete some opportunities
+        opportunities_to_delete = [opportunities.pop(), opportunities.pop(), opportunities.pop()]
+        for opportunity in opportunities_to_delete:
+            db_session.delete(opportunity)
+
+        load_opportunities_to_index.run()
+
+        resp = search_client.search(opportunity_index_alias, {"size": 100})
+        assert resp.total_records == len(opportunities)


### PR DESCRIPTION
## Summary
Fixes #179

### Time to review: __10 mins__

## Changes proposed
Updated the load search data task to partially support incrementally loading + deleting records in the search index rather than just fully remaking it.

Various changes to the search utilities to support this work

## Context for reviewers
Technically this doesn't fully support a true incremental load as it updates every record rather than just the ones with changes. I think the logic necessary to detect changes both deserves its own ticket, and may evolve when we later support indexing files to OpenSearch, so I think it makes sense to hold off on that for now.

