### PR TITLE
[Issue #181]Add no console log to eslint rules

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -51,6 +51,8 @@ module.exports = {
         "@typescript-eslint/no-explicit-any": "error",
         // Just warn since playwright tests may not use screen the way jest would
         "testing-library/prefer-screen-queries": "warn",
+        // Prevent unnecessary console statements
+        "no-console": ["error", { allow: ["warn", "error"] }],
       },
     },
   ],

--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -219,7 +219,7 @@ const throwError = (
   searchInputs?: QueryParamData,
   firstError?: APIResponseError,
 ) => {
-  console.log("Throwing error: ", message, status_code, searchInputs);
+  console.error("Throwing error: ", message, status_code, searchInputs);
 
   // Include just firstError for now, we can expand this
   // If we need ValidationErrors to be more expanded


### PR DESCRIPTION
## Summary
Fixes #181 

### Time to review: __1 mins__

## Changes proposed
> Added new rule to eslint to prevent leaving behind console log statements

## Context for reviewers
> normal expected rule in eslint configurations


