### PR TITLE
[Issue #188] More filters in search schema

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -220,6 +220,37 @@ paths:
                     page_offset: 1
                     page_size: 100
                     sort_direction: ascending
+              example5:
+                summary: Filter by award fields
+                value:
+                  filters:
+                    expected_number_of_awards:
+                      min: 5
+                    award_floor:
+                      min: 10000
+                    award_ceiling:
+                      max: 1000000
+                    estimated_total_program_funding:
+                      min: 100000
+                      max: 250000
+                  pagination:
+                    order_by: opportunity_id
+                    page_offset: 1
+                    page_size: 25
+                    sort_direction: descending
+              example6:
+                summary: FIlter by assistance listing numbers
+                value:
+                  filters:
+                    assistance_listing_number:
+                      one_of:
+                      - '43.001'
+                      - '47.049'
+                  pagination:
+                    order_by: opportunity_id
+                    page_offset: 1
+                    page_size: 25
+                    sort_direction: descending
       security:
       - ApiKeyAuth: []
   /v0.1/opportunities/search:
@@ -831,6 +862,86 @@ components:
             type: string
             minLength: 2
             example: USAID
+    AssistanceListingNumberFilterV1:
+      type: object
+      properties:
+        one_of:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            pattern: ^\d{2}\.\d{2,3}$
+            example: '45.149'
+    IsCostSharingFilterV1:
+      type: object
+      properties:
+        one_of:
+          type:
+          - array
+          - 'null'
+          items:
+            type: boolean
+            example: true
+    ExpectedNumberAwardsFilterV1:
+      type: object
+      properties:
+        min:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 0
+        max:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 25
+    AwardFloorFilterV1:
+      type: object
+      properties:
+        min:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 0
+        max:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 10000
+    AwardCeilingFilterV1:
+      type: object
+      properties:
+        min:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 0
+        max:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 10000000
+    EstimatedTotalProgramFundingFilterV1:
+      type: object
+      properties:
+        min:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 0
+        max:
+          type:
+          - integer
+          - 'null'
+          minimum: 0
+          example: 10000000
     PostDateFilterV1:
       type: object
       properties:
@@ -885,6 +996,36 @@ components:
           - object
           allOf:
           - $ref: '#/components/schemas/AgencyFilterV1'
+        assistance_listing_number:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/AssistanceListingNumberFilterV1'
+        is_cost_sharing:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/IsCostSharingFilterV1'
+        expected_number_of_awards:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/ExpectedNumberAwardsFilterV1'
+        award_floor:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/AwardFloorFilterV1'
+        award_ceiling:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/AwardCeilingFilterV1'
+        estimated_total_program_funding:
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/EstimatedTotalProgramFundingFilterV1'
         post_date:
           type:
           - object

--- a/api/src/api/opportunities_v1/opportunity_routes.py
+++ b/api/src/api/opportunities_v1/opportunity_routes.py
@@ -98,6 +98,37 @@ examples = {
             },
         },
     },
+    "example5": {
+        "summary": "Filter by award fields",
+        "value": {
+            "filters": {
+                "expected_number_of_awards": {"min": 5},
+                "award_floor": {"min": 10000},
+                "award_ceiling": {"max": 1000000},
+                "estimated_total_program_funding": {"min": 100000, "max": 250000},
+            },
+            "pagination": {
+                "order_by": "opportunity_id",
+                "page_offset": 1,
+                "page_size": 25,
+                "sort_direction": "descending",
+            },
+        },
+    },
+    "example6": {
+        "summary": "FIlter by assistance listing numbers",
+        "value": {
+            "filters": {
+                "assistance_listing_number": {"one_of": ["43.001", "47.049"]},
+            },
+            "pagination": {
+                "order_by": "opportunity_id",
+                "page_offset": 1,
+                "page_size": 25,
+                "sort_direction": "descending",
+            },
+        },
+    },
 }
 
 

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -2,7 +2,12 @@ from enum import StrEnum
 
 from src.api.schemas.extension import Schema, fields, validators
 from src.api.schemas.response_schema import AbstractResponseSchema, PaginationMixinSchema
-from src.api.schemas.search_schema import DateSearchSchemaBuilder, StrSearchSchemaBuilder
+from src.api.schemas.search_schema import (
+    BoolSearchSchemaBuilder,
+    DateSearchSchemaBuilder,
+    IntegerSearchSchemaBuilder,
+    StrSearchSchemaBuilder,
+)
 from src.constants.lookup_constants import (
     ApplicantType,
     FundingCategory,
@@ -318,6 +323,43 @@ class OpportunitySearchFilterV1Schema(Schema):
     agency = fields.Nested(
         StrSearchSchemaBuilder("AgencyFilterV1Schema")
         .with_one_of(example="USAID", minimum_length=2)
+        .build()
+    )
+    assistance_listing_number = fields.Nested(
+        StrSearchSchemaBuilder("AssistanceListingNumberFilterV1Schema")
+        .with_one_of(
+            example="45.149", pattern=r"^\d{2}\.\d{2,3}$"
+        )  # Always of the format ##.## or ##.###
+        .build()
+    )
+    is_cost_sharing = fields.Nested(
+        BoolSearchSchemaBuilder("IsCostSharingFilterV1Schema").with_one_of(example=True).build()
+    )
+    expected_number_of_awards = fields.Nested(
+        IntegerSearchSchemaBuilder("ExpectedNumberAwardsFilterV1Schema")
+        .with_minimum_value(example=0)
+        .with_maximum_value(example=25)
+        .build()
+    )
+
+    award_floor = fields.Nested(
+        IntegerSearchSchemaBuilder("AwardFloorFilterV1Schema")
+        .with_minimum_value(example=0)
+        .with_maximum_value(example=10_000)
+        .build()
+    )
+
+    award_ceiling = fields.Nested(
+        IntegerSearchSchemaBuilder("AwardCeilingFilterV1Schema")
+        .with_minimum_value(example=0)
+        .with_maximum_value(example=10_000_000)
+        .build()
+    )
+
+    estimated_total_program_funding = fields.Nested(
+        IntegerSearchSchemaBuilder("EstimatedTotalProgramFundingFilterV1Schema")
+        .with_minimum_value(example=0)
+        .with_maximum_value(example=10_000_000)
         .build()
     )
 

--- a/api/src/api/schemas/extension/field_validators.py
+++ b/api/src/api/schemas/extension/field_validators.py
@@ -7,6 +7,8 @@ from marshmallow import ValidationError
 from src.api.schemas.extension.schema_common import MarshmallowErrorContainer
 from src.validation.validation_constants import ValidationErrorType
 
+Validator = validators.Validator  # re-export
+
 
 class Regexp(validators.Regexp):
     REGEX_ERROR = MarshmallowErrorContainer(

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -122,6 +122,37 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
 
 
 class IntegerSearchSchemaBuilder(BaseSearchSchemaBuilder):
+    """
+    Builder for setting up a filter in a search endpoint schema for an integer.
+
+    Our schemas are setup to look like:
+
+        {
+            "filters": {
+                "field": {
+                    "min": 1,
+                    "max": 5
+                }
+            }
+        }
+
+    This helps generate the filters for a given field. At the moment,
+    only a min and max filter are implemented, and can be used to filter
+    on a range of values.
+
+    Usage::
+
+        # In a search request schema, you would use it like so
+
+        class OpportunitySearchFilterSchema(Schema):
+            example_int_field = fields.Nested(
+                IntegerSearchSchemaBuilder("ExampleIntFieldSchema")
+                    .with_minimum_value(example=1)
+                    .with_maximum_value(example=25)
+                    .build()
+            )
+    """
+
     def with_minimum_value(
         self, example: int | None = None, positive_only: bool = True
     ) -> "IntegerSearchSchemaBuilder":
@@ -156,6 +187,38 @@ class IntegerSearchSchemaBuilder(BaseSearchSchemaBuilder):
 
 
 class BoolSearchSchemaBuilder(BaseSearchSchemaBuilder):
+    """
+    Builder for setting up a filter in a search endpoint schema.
+
+    Our schemas are setup to look like:
+
+        {
+            "filters": {
+                "field": {
+                    "one_of": ["True", "False"]
+                }
+            }
+        }
+
+    This helps generate the filters for a given field. At the moment,
+    only a one_of filter is implemented - note that any truthy value
+    as determined by Marshmallow is accepted (including "yes", "y", 1 - for true)
+
+    While it doesn't quite make sense to filter by multiple boolean values in most cases,
+    we err on the side of consistency with the structure of the query to match other types.
+
+    Usage::
+
+        # In a search request schema, you would use it like so
+
+        class OpportunitySearchFilterSchema(Schema):
+            example_bool_field = fields.Nested(
+                BoolSearchSchemaBuilder("ExampleBoolFieldSchema")
+                    .with_one_of(example=True)
+                    .build()
+            )
+    """
+
     def with_one_of(self, example: bool | None = None) -> "BoolSearchSchemaBuilder":
         metadata = {}
         if example is not None:

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, Type
+from typing import Any, Pattern, Type
 
 from marshmallow import ValidationError, validates_schema
 
@@ -84,9 +84,13 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
         self,
         *,
         allowed_values: Type[StrEnum] | None = None,
+        pattern: str | Pattern | None = None,
         example: str | None = None,
         minimum_length: int | None = None
     ) -> "StrSearchSchemaBuilder":
+        if pattern is not None and allowed_values is not None:
+            raise Exception("Cannot specify both a pattern and allowed_values")
+
         metadata = {}
         if example:
             metadata["example"] = example
@@ -94,8 +98,16 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
         # We assume it's just a list of strings
         if allowed_values is None:
             params: dict = {"metadata": metadata}
+
+            field_validators: list[validators.Validator] = []
             if minimum_length is not None:
-                params["validate"] = [validators.Length(min=2)]
+                field_validators.append(validators.Length(min=minimum_length))
+
+            if pattern is not None:
+                field_validators.append(validators.Regexp(regex=pattern))
+
+            if len(field_validators) > 0:
+                params["validate"] = field_validators
 
             list_type: fields.MixinField = fields.String(**params)
 
@@ -106,6 +118,52 @@ class StrSearchSchemaBuilder(BaseSearchSchemaBuilder):
         # Note that the list requires at least one value (sending us just [] will raise a validation error)
         self.schema_fields["one_of"] = fields.List(list_type, validate=[validators.Length(min=1)])
 
+        return self
+
+
+class IntegerSearchSchemaBuilder(BaseSearchSchemaBuilder):
+    def with_minimum_value(
+        self, example: int | None = None, positive_only: bool = True
+    ) -> "IntegerSearchSchemaBuilder":
+        metadata = {}
+        if example is not None:
+            metadata["example"] = example
+
+        field_validators = []
+        if positive_only:
+            field_validators.append(validators.Range(min=0))
+
+        self.schema_fields["min"] = fields.Integer(
+            allow_none=True, metadata=metadata, validate=field_validators
+        )
+        return self
+
+    def with_maximum_value(
+        self, example: int | None = None, positive_only: bool = True
+    ) -> "IntegerSearchSchemaBuilder":
+        metadata = {}
+        if example is not None:
+            metadata["example"] = example
+
+        field_validators = []
+        if positive_only:
+            field_validators.append(validators.Range(min=0))
+
+        self.schema_fields["max"] = fields.Integer(
+            allow_none=True, metadata=metadata, validate=field_validators
+        )
+        return self
+
+
+class BoolSearchSchemaBuilder(BaseSearchSchemaBuilder):
+    def with_one_of(self, example: bool | None = None) -> "BoolSearchSchemaBuilder":
+        metadata = {}
+        if example is not None:
+            metadata["example"] = example
+
+        self.schema_fields["one_of"] = fields.List(
+            fields.Boolean(metadata=metadata), allow_none=True
+        )
         return self
 
 

--- a/api/tests/src/api/opportunities_v1/conftest.py
+++ b/api/tests/src/api/opportunities_v1/conftest.py
@@ -37,6 +37,12 @@ def get_search_request(
     applicant_type_one_of: list[ApplicantType] | None = None,
     opportunity_status_one_of: list[OpportunityStatus] | None = None,
     agency_one_of: list[str] | None = None,
+    assistance_listing_one_of: list[str] = None,
+    is_cost_sharing_one_of: list[bool | str] | None = None,
+    expected_number_of_awards: dict | None = None,
+    award_floor: dict | None = None,
+    award_ceiling: dict | None = None,
+    estimated_total_program_funding: dict | None = None,
     post_date: dict | None = None,
     close_date: dict | None = None,
     format: str | None = None,
@@ -66,6 +72,24 @@ def get_search_request(
 
     if agency_one_of is not None:
         filters["agency"] = {"one_of": agency_one_of}
+
+    if assistance_listing_one_of is not None:
+        filters["assistance_listing_number"] = {"one_of": assistance_listing_one_of}
+
+    if is_cost_sharing_one_of is not None:
+        filters["is_cost_sharing"] = {"one_of": is_cost_sharing_one_of}
+
+    if expected_number_of_awards is not None:
+        filters["expected_number_of_awards"] = expected_number_of_awards
+
+    if award_floor is not None:
+        filters["award_floor"] = award_floor
+
+    if award_ceiling is not None:
+        filters["award_ceiling"] = award_ceiling
+
+    if estimated_total_program_funding is not None:
+        filters["estimated_total_program_funding"] = estimated_total_program_funding
 
     if post_date is not None:
         filters["post_date"] = post_date


### PR DESCRIPTION
## Summary
Fixes #188

### Time to review: __5 mins__

## Changes proposed
Added a builder for the search schema for integer and boolean fields.

Updated the string builder to fix a small bug + allow you to specify a pattern for the string.

## Context for reviewers
This is just adding additional filters that we'll be able to search by (once the rest of the implementation is built out). These are all fields that fall into a "yeah, I think someone might want to narrow down by that" group, and definitely doesn't encompass every filter we might want to add. Mostly just wanted to get integer and boolean fields implemented so the search logic could all get built out with actual use cases.

## Additional information
Added examples to the OpenAPI docs to verify these work, at least at the request parsing phase.

