### PR TITLE
Update layout.tsx to fix 404 not rendering

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,5 +6,9 @@ type Props = {
 };
 
 export default function RootLayout({ children }: Props) {
-  return children;
+  return (
+    <html suppressHydrationWarning>
+      <body>{children}</body>
+    </html>
+  );
 }


### PR DESCRIPTION
## Summary

404 pages had the following issue:

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/f7350f42-9c32-4ab8-b606-c1fa0dd25151">

This PR fixes that by adding the `<html><body>...` in the top level layout.

This error only appears in dev.

### Time to review: __5 mins__
